### PR TITLE
Fix installation instructions to reflect end user interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A React App for visualizing a singly-linked list data structure.
 ## Installation
 Install packages
 ```bash
-npm install create-react-app
+npm install
 ```
 
 ## Usage


### PR DESCRIPTION
An end user does not need the create-react-app dependency, since create-react-app just generates the boilerplate. However, they do need the packages specified in package.json. Those can be installed with
```bash
npm install
```